### PR TITLE
Adding a "Deselect All" button

### DIFF
--- a/src/pages/sessionManager.html
+++ b/src/pages/sessionManager.html
@@ -77,6 +77,7 @@
                 </div>
             </div>
             <div class="modal-footer align-right">
+                <button class="button-secondary" name="deselectAll">Deselect all</button>
                 <button class="button-secondary" name="closeSave">Close</button>
                 <button class="button-primary" name="save">OK</button>
             </div>

--- a/src/pages/sessionManager.html
+++ b/src/pages/sessionManager.html
@@ -102,6 +102,7 @@
                 </div>
             </div>
             <div class="modal-footer align-right">
+                <button class="button-secondary" name="deselectAll">Deselect all</button>
                 <button class="button-secondary" name="closeEdit">Close</button>
                 <button class="button-primary" name="edit">OK</button>
             </div>

--- a/src/scripts/events.js
+++ b/src/scripts/events.js
@@ -66,9 +66,8 @@ document.addEventListener("click", (e) => {
                 hideModal("loadModal");
             }
         }
-
         else if (action.includes("deselectAll")) {
-            var container = document.getElementById("editSelectionContainer");
+            let container = document.getElementById("editSelectionContainer");
             deselectAll(container);
         }
 

--- a/src/scripts/events.js
+++ b/src/scripts/events.js
@@ -67,6 +67,10 @@ document.addEventListener("click", (e) => {
             }
         }
 
+        else if (action.includes("deselectAll")) {
+            var container = document.getElementById("editSelectionContainer");
+            deselectAll(container);
+        }
 
         // Actions
         if (/(download|delete|edit|load)/.test(action)) {

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -194,7 +194,7 @@ const getSelectionData = (container = null, keys = null, keysLength = 0) => {
 }
 
 const deselectAll = (container = null) => {
-    var selAlls = container.querySelectorAll('.selAll');
+    let selAlls = container.querySelectorAll('.selAll');
     for (var i = 0; i < selAlls.length; i++) {
         var selAll = selAlls[i];
         selAll.checked = false;

--- a/src/scripts/utils.js
+++ b/src/scripts/utils.js
@@ -193,6 +193,15 @@ const getSelectionData = (container = null, keys = null, keysLength = 0) => {
     return sessionData;
 }
 
+const deselectAll = (container = null) => {
+    var selAlls = container.querySelectorAll('.selAll');
+    for (var i = 0; i < selAlls.length; i++) {
+        var selAll = selAlls[i];
+        selAll.checked = false;
+        toggleSelect(selAll, "Win" + i);
+    }
+}
+
 const doUrlAction = (url = "https://www.paypal.me/ITDominator", fileName = "", isDownload = false) => {
     let aTagElm = document.getElementById('downloadAnchorElem');
     aTagElm.setAttribute("href", url);


### PR DESCRIPTION
Adding a "Deselect All" button so that you don't need to uncheck all other sessions in a multi-session environment every time you want to save three single-window session out of, say, 50 windows.

I have 88 windows open at the moment (with 1588 tabs), and I want to clean it up some by saving sessions until they're needed. Picked your extension because you seem active when it comes to development and responses to users, and decided I'd try developing the feature I currently need the most =) Tested this and it works for me, let me know if I need to make any changes.

Cheers!
Arsenijs